### PR TITLE
chore: promote python-http-desktop to version 0.0.1 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/python-http-desktop/python-http-desktop-0.0.1-release.yaml
+++ b/config-root/namespaces/jx-staging/python-http-desktop/python-http-desktop-0.0.1-release.yaml
@@ -1,0 +1,59 @@
+# Source: python-http-desktop/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-31T04:14:02Z"
+  deletionTimestamp: null
+  name: 'python-http-desktop-0.0.1'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 0.0.1
+      sha: 183aa520e79f2a14e9f2f65913a0c8d0e52c2a57
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 0a42d5646404c36f5cd1a68dd9beddc062c45455
+    - author:
+        email: spinmaster@gmail.com
+        name: twotired
+      branch: master
+      committer:
+        email: spinmaster@gmail.com
+        name: twotired
+      message: |
+        test
+      sha: d1496e6a78f92df2fc19b44c03221d69b9a713a4
+    - author:
+        email: spinmaster@gmail.com
+        name: twotired
+      branch: master
+      committer:
+        email: spinmaster@gmail.com
+        name: twotired
+      message: |
+        chore: Jenkins X build pack
+      sha: 7818e2988ee0eb9a237b8f6252b16894fdb7062f
+  gitHttpUrl: https://github.com/twotired/python-http-desktop
+  gitOwner: twotired
+  gitRepository: python-http-desktop
+  name: 'python-http-desktop'
+  releaseNotesURL: https://github.com/twotired/python-http-desktop/releases/tag/v0.0.1
+  version: v0.0.1
+status: {}

--- a/config-root/namespaces/jx-staging/python-http-desktop/python-http-desktop-ingress.yaml
+++ b/config-root/namespaces/jx-staging/python-http-desktop/python-http-desktop-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: python-http-desktop/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: python-http-desktop
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: python-http-desktop
+              servicePort: 80
+      host: python-http-desktop-jx-staging.192.168.39.211.nip.io

--- a/config-root/namespaces/jx-staging/python-http-desktop/python-http-desktop-python-http-desktop-deploy.yaml
+++ b/config-root/namespaces/jx-staging/python-http-desktop/python-http-desktop-python-http-desktop-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: python-http-desktop/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: python-http-desktop-python-http-desktop
+  labels:
+    draft: draft-app
+    chart: "python-http-desktop-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: python-http-desktop-python-http-desktop
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: python-http-desktop-python-http-desktop
+    spec:
+      serviceAccountName: python-http-desktop-python-http-desktop
+      containers:
+        - name: python-http-desktop
+          image: "10.111.107.146/twotired/python-http-desktop:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/python-http-desktop/python-http-desktop-python-http-desktop-sa.yaml
+++ b/config-root/namespaces/jx-staging/python-http-desktop/python-http-desktop-python-http-desktop-sa.yaml
@@ -1,0 +1,8 @@
+# Source: python-http-desktop/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: python-http-desktop-python-http-desktop
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/python-http-desktop/python-http-desktop-svc.yaml
+++ b/config-root/namespaces/jx-staging/python-http-desktop/python-http-desktop-svc.yaml
@@ -1,0 +1,21 @@
+# Source: python-http-desktop/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: python-http-desktop
+  labels:
+    chart: "python-http-desktop-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: python-http-desktop-python-http-desktop

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: go-http-desktop
   values:
   - jx-values.yaml
+- chart: dev/python-http-desktop
+  version: 0.0.1
+  name: python-http-desktop
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -16,5 +16,7 @@ releases:
 - chart: dev/python-http-desktop
   version: 0.0.1
   name: python-http-desktop
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote python-http-desktop to version 0.0.1 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge