### PR TITLE
chore: promote go-http-desktop to version 0.0.2 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/go-http-desktop/go-http-desktop-0.0.2-release.yaml
+++ b/config-root/namespaces/jx-staging/go-http-desktop/go-http-desktop-0.0.2-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-31T03:54:01Z"
+  creationTimestamp: "2020-12-31T07:23:20Z"
   deletionTimestamp: null
-  name: 'go-http-desktop-0.0.1'
+  name: 'go-http-desktop-0.0.2'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.1
-      sha: ec60fd76341caa0690c85e8845affed60a521b65
+        chore: release 0.0.2
+      sha: d357a26ca7023fc5a428fc53fc8b8ff23060532f
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,31 +29,23 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 97600a236e6d57f2e0b0d689aa5710a41010f6db
+      sha: f63602dd7dd61acb83a054b429540e588f30c974
     - author:
         email: spinmaster@gmail.com
-        name: twotired
+        name: Jason Wells
       branch: master
       committer:
-        email: spinmaster@gmail.com
-        name: twotired
-      message: |
-        fixing
-      sha: f61a3d014c5df12c05ea8d4a0fc9bbe2bd85b607
-    - author:
-        email: spinmaster@gmail.com
-        name: twotired
-      branch: master
-      committer:
-        email: spinmaster@gmail.com
-        name: twotired
-      message: |
-        chore: Jenkins X build pack
-      sha: 619264a715d6f4786134e01355f41df4201913f9
+        email: noreply@github.com
+        name: GitHub
+      message: |-
+        Update README.md
+
+        asdfasdf
+      sha: bd196a52ec1e5d5fd4e9853f1613beeb1e51701b
   gitHttpUrl: https://github.com/twotired/go-http-desktop
   gitOwner: twotired
   gitRepository: go-http-desktop
   name: 'go-http-desktop'
-  releaseNotesURL: https://github.com/twotired/go-http-desktop/releases/tag/v0.0.1
-  version: v0.0.1
+  releaseNotesURL: https://github.com/twotired/go-http-desktop/releases/tag/v0.0.2
+  version: v0.0.2
 status: {}

--- a/config-root/namespaces/jx-staging/go-http-desktop/go-http-desktop-go-http-desktop-deploy.yaml
+++ b/config-root/namespaces/jx-staging/go-http-desktop/go-http-desktop-go-http-desktop-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: go-http-desktop-go-http-desktop
   labels:
     draft: draft-app
-    chart: "go-http-desktop-0.0.1"
+    chart: "go-http-desktop-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: go-http-desktop-go-http-desktop
       containers:
         - name: go-http-desktop
-          image: "10.111.107.146/twotired/go-http-desktop:0.0.1"
+          image: "10.111.107.146/twotired/go-http-desktop:0.0.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.2
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/go-http-desktop/go-http-desktop-svc.yaml
+++ b/config-root/namespaces/jx-staging/go-http-desktop/go-http-desktop-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: go-http-desktop
   labels:
-    chart: "go-http-desktop-0.0.1"
+    chart: "go-http-desktop-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
 releases:
 - chart: dev/go-http-desktop
-  version: 0.0.1
+  version: 0.0.2
   name: go-http-desktop
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote go-http-desktop to version 0.0.2 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge